### PR TITLE
Fix children expansion edge filtering

### DIFF
--- a/apps/docling_graph/main.py
+++ b/apps/docling_graph/main.py
@@ -572,7 +572,7 @@ def expand_on_click(node_data, elements, store_graph, node_index, mode, page_ran
         d = ed["data"]
         src, tgt, rel = d.get("source"), d.get("target"), d.get("rel")
 
-        if mode == "children" and not (rel == "hier" and src == node_id):
+        if mode == "children" and not (src == node_id or tgt == node_id):
             continue
         if mode == "out" and src != node_id:
             continue


### PR DESCRIPTION
## Summary
- allow children expansion mode to load any edges connected to the tapped node instead of only hierarchical ones
- maintain graph exploration by ensuring default expansion reveals connected edges

## Testing
- PYTHONPATH=. pytest

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69444bb541e0832eb8b1f0283de4b593)