### PR TITLE
Fix children expansion edge filtering

### DIFF
--- a/apps/docling_graph/main.py
+++ b/apps/docling_graph/main.py
@@ -497,17 +497,23 @@ def show_page_range(value):
     prevent_initial_call=True,
 )
 def expand_on_click(node_data, elements, store_graph, node_index, mode, page_range):
-    if not node_data or not store_graph or not page_range:
+    if not node_data or not store_graph:
         return no_update
+
+    elements = elements or []
 
     node_id = node_data.get("id")
     if not node_id:
         return no_update
 
-    start_page, end_page = page_range
+    start_page, end_page = (page_range or (None, None))
 
     def in_range(page):
-        return page is None or (start_page <= page <= end_page)
+        if page is None:
+            return True
+        if start_page is None or end_page is None:
+            return True
+        return start_page <= page <= end_page
 
     existing_nodes = {e["data"]["id"] for e in elements if "id" in e.get("data", {})}
     existing_edges = {e["data"]["id"] for e in elements if "source" in e.get("data", {})}
@@ -572,7 +578,7 @@ def expand_on_click(node_data, elements, store_graph, node_index, mode, page_ran
         d = ed["data"]
         src, tgt, rel = d.get("source"), d.get("target"), d.get("rel")
 
-        if mode == "children" and not (rel == "hier" and src == node_id):
+        if mode == "children" and not (src == node_id or tgt == node_id):
             continue
         if mode == "out" and src != node_id:
             continue


### PR DESCRIPTION
## Summary
- allow children expansion mode to load any edges connected to the tapped node instead of only hierarchical ones
- maintain graph exploration by ensuring default expansion reveals connected edges
- handle missing or unset page range values so root expansion works immediately
- default to an empty element list so root expansion works even if graph state has not yet populated

## Testing
- PYTHONPATH=. pytest

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69444bb541e0832eb8b1f0283de4b593)