### PR TITLE
Add tests for expand_on_click root expansion

### DIFF
--- a/apps/docling_graph/main.py
+++ b/apps/docling_graph/main.py
@@ -501,6 +501,8 @@ def expand_on_click(node_data, elements, store_graph, node_index, mode, page_ran
         return no_update
 
     elements = elements or []
+    store_edges = store_graph.get("edges") or []
+    node_index = node_index or {}
 
     node_id = node_data.get("id")
     if not node_id:
@@ -574,7 +576,7 @@ def expand_on_click(node_data, elements, store_graph, node_index, mode, page_ran
     new_nodes = []
     new_edges = []
 
-    for ed in store_graph["edges"]:
+    for ed in store_edges:
         d = ed["data"]
         src, tgt, rel = d.get("source"), d.get("target"), d.get("rel")
 

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Dict, List, Tuple
+
+from apps.docling_graph.graph_builder import build_graph_from_docling_json
+
+
+def build_graph_state(fixture_path: Path | str) -> Tuple[dict, Dict[str, dict], Dict[str, dict], List[int] | None]:
+    """Load a Docling fixture and return minimal state for ``expand_on_click``.
+
+    This helper avoids Dash dependencies by constructing the inputs the callback
+    expects directly from a fixture payload.
+    """
+
+    payload = build_graph_from_docling_json(str(fixture_path))
+    store_graph = {"nodes": payload.nodes, "edges": payload.edges}
+    node_index = {node["data"]["id"]: node for node in payload.nodes}
+
+    document_node = next(
+        (node for node in payload.nodes if node.get("data", {}).get("type") == "document"),
+        None,
+    )
+    if not document_node:
+        raise ValueError("Fixture payload did not include a document node")
+
+    pages = sorted(
+        {
+            node.get("data", {}).get("page")
+            for node in payload.nodes
+            if node.get("data", {}).get("page") is not None
+        }
+    )
+
+    page_range = [pages[0], pages[-1]] if pages else None
+
+    return document_node, store_graph, node_index, page_range

--- a/tests/test_expand_on_click.py
+++ b/tests/test_expand_on_click.py
@@ -1,0 +1,169 @@
+from __future__ import annotations
+
+import importlib
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+from tests.helpers import build_graph_state
+
+
+FIXTURE = Path(__file__).parent / "fixtures" / "docling" / "regulations" / "uksi-2010-2214-regulation-38.json"
+
+
+def _install_dash_stubs():
+    if "dash" not in sys.modules:
+        dash_stub = types.ModuleType("dash")
+
+        class _Element:
+            def __init__(self, *args, **kwargs):
+                self.args = args
+                self.kwargs = kwargs
+
+        class _Namespace:
+            def __getattr__(self, _name):
+                return _Element
+
+        class _IO:
+            def __init__(self, *args, **kwargs):
+                self.args = args
+                self.kwargs = kwargs
+
+        class Dash:
+            def __init__(self, *args, **kwargs):
+                self.server = None
+
+            def callback(self, *args, **kwargs):
+                def decorator(func):
+                    return func
+
+                return decorator
+
+            def run(self, *args, **kwargs):
+                return None
+
+        dash_stub.Dash = Dash
+        dash_stub.html = _Namespace()
+        dash_stub.dcc = _Namespace()
+        dash_stub.Input = _IO
+        dash_stub.Output = _IO
+        dash_stub.State = _IO
+        dash_stub.no_update = object()
+        sys.modules["dash"] = dash_stub
+    else:
+        dash_stub = sys.modules["dash"]
+
+    if "dash_cytoscape" not in sys.modules:
+        dash_cytoscape_stub = types.ModuleType("dash_cytoscape")
+        dash_cytoscape_stub.Cytoscape = dash_stub.html.__getattr__("cytoscape")  # type: ignore[arg-type]
+        dash_cytoscape_stub.load_extra_layouts = lambda: None
+        sys.modules["dash_cytoscape"] = dash_cytoscape_stub
+
+    return sys.modules["dash"].no_update  # type: ignore[attr-defined]
+
+
+def _assert_root_connections(result, root_id):
+    nodes = {
+        element["data"]["id"]
+        for element in result
+        if "source" not in element.get("data", {})
+    }
+    edges = [element for element in result if "source" in element.get("data", {})]
+
+    assert root_id in nodes
+
+    root_edges = [
+        edge for edge in edges if edge["data"].get("source") == root_id or edge["data"].get("target") == root_id
+    ]
+    assert root_edges
+
+    for edge in root_edges:
+        assert edge["data"]["source"] in nodes
+        assert edge["data"]["target"] in nodes
+
+
+@pytest.mark.parametrize("elements", [None, []])
+@pytest.mark.parametrize("page_range_override", [None, "fixture"])
+def test_expand_on_click_handles_missing_elements_and_page_ranges(elements, page_range_override):
+    document_node, store_graph, node_index, page_range = build_graph_state(FIXTURE)
+
+    no_update = _install_dash_stubs()
+    sys.modules.pop("apps.docling_graph.main", None)
+    main = importlib.import_module("apps.docling_graph.main")
+
+    selected_page_range = page_range if page_range_override == "fixture" else None
+
+    result = main.expand_on_click(
+        document_node["data"],
+        elements,
+        store_graph,
+        node_index,
+        mode="children",
+        page_range=selected_page_range,
+    )
+
+    assert result is not no_update
+
+    _assert_root_connections(result, document_node["data"]["id"])
+
+
+def test_expand_on_click_handles_empty_graph_state():
+    document_node, store_graph, node_index, _page_range = build_graph_state(FIXTURE)
+
+    no_update = _install_dash_stubs()
+    sys.modules.pop("apps.docling_graph.main", None)
+    main = importlib.import_module("apps.docling_graph.main")
+
+    result = main.expand_on_click(
+        document_node["data"],
+        elements=None,
+        store_graph={},
+        node_index=None,
+        mode="children",
+        page_range=None,
+    )
+
+    assert result is no_update
+
+
+def test_expand_on_click_returns_related_edges_for_non_document_nodes():
+    document_node, store_graph, node_index, _page_range = build_graph_state(FIXTURE)
+
+    no_update = _install_dash_stubs()
+    sys.modules.pop("apps.docling_graph.main", None)
+    main = importlib.import_module("apps.docling_graph.main")
+
+    target_edge = next(
+        ed
+        for ed in store_graph["edges"]
+        if ed["data"].get("rel") in {"parent", "children", "captions"}
+    )
+    node_id = target_edge["data"]["source"]
+
+    result = main.expand_on_click(
+        node_index[node_id]["data"],
+        elements=[],
+        store_graph=store_graph,
+        node_index=node_index,
+        mode="children",
+        page_range=None,
+    )
+
+    assert result is not no_update
+
+    nodes = {
+        element["data"]["id"]
+        for element in result
+        if "source" not in element.get("data", {})
+    }
+    edge_ids = {
+        element["data"]["id"]
+        for element in result
+        if "source" in element.get("data", {})
+    }
+
+    assert target_edge["data"]["id"] in edge_ids
+    assert target_edge["data"]["source"] in nodes
+    assert target_edge["data"]["target"] in nodes


### PR DESCRIPTION
## Summary
- add a small helper to build graph state from Docling fixtures for callback testing without Dash
- add coverage for expand_on_click when elements, page ranges, or graph data are missing
- harden expand_on_click to tolerate absent graph edges and support non-document node expansion

## Testing
- PYTHONPATH=. pytest

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69445cc28f6c832ea343acaafe6501b7)