### PR TITLE
Fix document dropdown scanning + disable caching in Docling Graph Viewer

### DIFF
--- a/apps/docling_graph/graph_builder.py
+++ b/apps/docling_graph/graph_builder.py
@@ -23,8 +23,8 @@ def _candidate_json_roots() -> List[str]:
     return [DEFAULT_JSON_ROOT, sibling_workspace, parent_workspace]
 
 
-def _docling_json_root() -> str:
-    override = os.environ.get("DOCLING_JSON_ROOT")
+def _docling_docs_root() -> str:
+    override = os.environ.get("DOCLING_DOCS_DIR") or os.environ.get("DOCLING_JSON_ROOT")
     if override:
         return (
             os.path.abspath(os.path.join(REPO_ROOT, override))
@@ -39,7 +39,12 @@ def _docling_json_root() -> str:
     return DEFAULT_JSON_ROOT
 
 
-DOCLING_JSON_ROOT = _docling_json_root()
+DOCLING_DOCS_DIR = _docling_docs_root()
+print(f"[docling_graph] Using documents directory: {DOCLING_DOCS_DIR}")
+
+
+def docling_docs_root() -> str:
+    return _docling_docs_root()
 
 MIN_TEXT_LEN = 40
 MAX_TEXTS_PER_PAGE = 250
@@ -100,16 +105,16 @@ def _short(text: str, limit: int = 120) -> str:
 
 def list_docling_files(json_root: Optional[str] = None) -> List[str]:
     results: List[str] = []
-    search_root = json_root or _docling_json_root()
+    search_root = Path(json_root or docling_docs_root())
 
-    if not os.path.isdir(search_root):
+    if not search_root.is_dir():
         return results
 
-    for root, _, files in os.walk(search_root):
-        for name in files:
-            if name.lower().endswith(".json"):
-                results.append(os.path.join(root, name))
-    return sorted(results)
+    for candidate in search_root.iterdir():
+        if candidate.is_file() and candidate.suffix.lower() == ".json":
+            results.append(str(candidate))
+
+    return sorted(results, key=lambda p: Path(p).name.lower())
 
 
 def _is_noise_text(label: str, text: str) -> bool:

--- a/apps/docling_graph/main.py
+++ b/apps/docling_graph/main.py
@@ -3,12 +3,15 @@ from __future__ import annotations
 import hashlib
 import os
 import json
+from datetime import datetime, timezone
 from pathlib import Path
 from dash import Dash, html, dcc, Input, Output, State, no_update
 import dash_cytoscape as cyto
+from flask import Response
 
 from .graph_builder import (
     build_graph_from_docling_json,
+    docling_docs_root,
     list_docling_files,
     GraphPayload,
 )
@@ -205,8 +208,6 @@ def base_stylesheet(node_size, font_size, text_max_width, show_edge_labels):
 # -------------------------------------------------
 # App + Defaults
 # -------------------------------------------------
-files = list_docling_files()
-
 DEFAULT_VIEW = {
     "layout": "dagre",
     "scaling_ratio": 250,
@@ -231,6 +232,7 @@ app.layout = html.Div(
     children=[
         dcc.Store(id="store_graph"),
         dcc.Store(id="store_node_index"),
+        dcc.Interval(id="docs_refresh", interval=500, n_intervals=0, max_intervals=1),
 
         html.Div(
             className="row",
@@ -297,12 +299,16 @@ app.layout = html.Div(
                                                         html.Div("Document", className="control-label"),
                                                         dcc.Dropdown(
                                                             id="file",
-                                                            options=[{"label": f, "value": f} for f in files],
-                                                            value=(files[0] if files else None),
+                                                            options=[],
+                                                            value=None,
                                                             clearable=False,
                                                         ),
                                                         html.Div(
                                                             id="data_source_label",
+                                                            className="control-subtext",
+                                                        ),
+                                                        html.Div(
+                                                            id="doc_scan_info",
                                                             className="control-subtext",
                                                         ),
                                                         html.Div(
@@ -422,6 +428,38 @@ app.layout = html.Div(
 # -------------------------------------------------
 # Callbacks
 # -------------------------------------------------
+@server.route("/api/documents")
+def list_documents_api():
+    scan_root = docling_docs_root()
+    payload = {"documents": list_docling_files(scan_root), "scan_root": scan_root}
+    response = Response(json.dumps(payload), mimetype="application/json")
+    response.headers["Cache-Control"] = "no-store"
+    return response
+
+
+@app.callback(
+    Output("file", "options"),
+    Output("file", "value"),
+    Output("doc_scan_info", "children"),
+    Input("docs_refresh", "n_intervals"),
+    State("file", "value"),
+)
+def refresh_document_options(_n_intervals, current_value):
+    scan_root = docling_docs_root()
+    doc_paths = list_docling_files(scan_root)
+    options = [{"label": Path(path).name, "value": path} for path in doc_paths]
+    value = current_value if current_value in doc_paths else (doc_paths[0] if doc_paths else None)
+    scanned_at = datetime.now(timezone.utc).isoformat()
+
+    scan_info = [
+        html.Div(f"Scan root: {scan_root}"),
+        html.Div(f"Found: {len(doc_paths)}"),
+        html.Div(f"Last scan: {scanned_at}"),
+    ]
+
+    return options, value, scan_info
+
+
 @app.callback(
     Output("graph", "elements"),
     Output("store_graph", "data"),
@@ -501,6 +539,8 @@ def expand_on_click(node_data, elements, store_graph, node_index, mode, page_ran
         return no_update
 
     elements = elements or []
+    store_edges = store_graph.get("edges") or []
+    node_index = node_index or {}
 
     node_id = node_data.get("id")
     if not node_id:
@@ -574,7 +614,7 @@ def expand_on_click(node_data, elements, store_graph, node_index, mode, page_ran
     new_nodes = []
     new_edges = []
 
-    for ed in store_graph["edges"]:
+    for ed in store_edges:
         d = ed["data"]
         src, tgt, rel = d.get("source"), d.get("target"), d.get("rel")
 

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Dict, List, Tuple
+
+from apps.docling_graph.graph_builder import build_graph_from_docling_json
+
+
+def build_graph_state(fixture_path: Path | str) -> Tuple[dict, Dict[str, dict], Dict[str, dict], List[int] | None]:
+    """Load a Docling fixture and return minimal state for ``expand_on_click``.
+
+    This helper avoids Dash dependencies by constructing the inputs the callback
+    expects directly from a fixture payload.
+    """
+
+    payload = build_graph_from_docling_json(str(fixture_path))
+    store_graph = {"nodes": payload.nodes, "edges": payload.edges}
+    node_index = {node["data"]["id"]: node for node in payload.nodes}
+
+    document_node = next(
+        (node for node in payload.nodes if node.get("data", {}).get("type") == "document"),
+        None,
+    )
+    if not document_node:
+        raise ValueError("Fixture payload did not include a document node")
+
+    pages = sorted(
+        {
+            node.get("data", {}).get("page")
+            for node in payload.nodes
+            if node.get("data", {}).get("page") is not None
+        }
+    )
+
+    page_range = [pages[0], pages[-1]] if pages else None
+
+    return document_node, store_graph, node_index, page_range

--- a/tests/test_docling_graph_builder.py
+++ b/tests/test_docling_graph_builder.py
@@ -1,9 +1,13 @@
+import importlib
 import json
+import os
+import sys
 import tempfile
 import unittest
 from pathlib import Path
 
 from apps.docling_graph import graph_builder as gb
+from tests.test_expand_on_click import _install_dash_stubs
 
 FIXTURES_ROOT = Path(__file__).resolve().parent / "fixtures" / "docling"
 SMALL_FIXTURE = FIXTURES_ROOT / "regulations" / "uksi-2010-2214-regulation-38.json"
@@ -11,11 +15,14 @@ SMALL_FIXTURE = FIXTURES_ROOT / "regulations" / "uksi-2010-2214-regulation-38.js
 
 class DoclingGraphBuilderFixtureTests(unittest.TestCase):
     def test_discovery_finds_fixture_jsons(self):
-        files = gb.list_docling_files(str(FIXTURES_ROOT))
-        names = {Path(f).name for f in files}
+        building_files = gb.list_docling_files(str(FIXTURES_ROOT / "building_standards"))
+        regulation_files = gb.list_docling_files(str(FIXTURES_ROOT / "regulations"))
 
-        self.assertIn("2025_Amendments_to_Approved_Document_B_volume_1_and_volume_2.json", names)
-        self.assertIn("uksi-2010-2214-regulation-38.json", names)
+        building_names = {Path(f).name for f in building_files}
+        regulation_names = {Path(f).name for f in regulation_files}
+
+        self.assertEqual(building_names, {"2025_Amendments_to_Approved_Document_B_volume_1_and_volume_2.json"})
+        self.assertEqual(regulation_names, {"uksi-2010-2214-regulation-38.json"})
 
     def test_loader_normalizes_docling_document(self):
         plain = {"texts": []}
@@ -98,6 +105,62 @@ class DoclingGraphBuilderFixtureTests(unittest.TestCase):
         self.assertIn(("#/texts/1", "#/body", "parent"), edges)
         self.assertIn(("#/pictures/0", "#/texts/1", "captions"), edges)
         self.assertTrue(any(e[2] == "document" for e in edges))
+
+    def test_list_docling_files_is_non_recursive(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            top_level = root / "root.json"
+            nested_dir = root / "nested"
+            nested_dir.mkdir()
+            nested = nested_dir / "nested.json"
+
+            top_level.write_text("{}", encoding="utf-8")
+            nested.write_text("{}", encoding="utf-8")
+
+            results = gb.list_docling_files(tmpdir)
+
+        self.assertEqual(results, [str(top_level)])
+
+    def test_list_docling_files_sorted_by_filename(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            first = root / "b.JSON"
+            second = root / "A.json"
+            first.write_text("{}", encoding="utf-8")
+            second.write_text("{}", encoding="utf-8")
+
+            results = gb.list_docling_files(tmpdir)
+
+        self.assertEqual(results, [str(second), str(first)])
+
+    def test_documents_endpoint_disables_caching_and_reflects_scan_root(self):
+        previous_root = os.environ.get("DOCLING_DOCS_DIR")
+        try:
+            with tempfile.TemporaryDirectory() as tmpdir:
+                root = Path(tmpdir)
+                doc_path = root / "test.json"
+                doc_path.write_text("{}", encoding="utf-8")
+
+                os.environ["DOCLING_DOCS_DIR"] = str(root)
+
+                _install_dash_stubs()
+                sys.modules.pop("apps.docling_graph.main", None)
+                from apps.docling_graph import main as main_app
+
+                importlib.reload(main_app)
+
+                response = main_app.list_documents_api()
+
+            payload = response.get_json()
+
+            self.assertEqual(response.headers.get("Cache-Control"), "no-store")
+            self.assertEqual(payload.get("scan_root"), str(root))
+            self.assertEqual(payload.get("documents"), [str(doc_path)])
+        finally:
+            if previous_root is None:
+                os.environ.pop("DOCLING_DOCS_DIR", None)
+            else:
+                os.environ["DOCLING_DOCS_DIR"] = previous_root
 
     def test_provenance_optional_does_not_crash(self):
         doc = {

--- a/tests/test_expand_on_click.py
+++ b/tests/test_expand_on_click.py
@@ -1,0 +1,199 @@
+from __future__ import annotations
+
+import importlib
+import json
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+from tests.helpers import build_graph_state
+
+
+FIXTURE = Path(__file__).parent / "fixtures" / "docling" / "regulations" / "uksi-2010-2214-regulation-38.json"
+
+
+def _install_dash_stubs():
+    if "dash" not in sys.modules:
+        dash_stub = types.ModuleType("dash")
+
+        class _Element:
+            def __init__(self, *args, **kwargs):
+                self.args = args
+                self.kwargs = kwargs
+
+        class _Namespace:
+            def __getattr__(self, _name):
+                return _Element
+
+        class _Server:
+            def __init__(self):
+                self.routes = {}
+
+            def route(self, path, **_kwargs):
+                def decorator(func):
+                    self.routes[path] = func
+                    return func
+
+                return decorator
+
+        class _IO:
+            def __init__(self, *args, **kwargs):
+                self.args = args
+                self.kwargs = kwargs
+
+        class Dash:
+            def __init__(self, *args, **kwargs):
+                self.server = _Server()
+
+            def callback(self, *args, **kwargs):
+                def decorator(func):
+                    return func
+
+                return decorator
+
+            def run(self, *args, **kwargs):
+                return None
+
+        dash_stub.Dash = Dash
+        dash_stub.html = _Namespace()
+        dash_stub.dcc = _Namespace()
+        dash_stub.Input = _IO
+        dash_stub.Output = _IO
+        dash_stub.State = _IO
+        dash_stub.no_update = object()
+        sys.modules["dash"] = dash_stub
+    else:
+        dash_stub = sys.modules["dash"]
+
+    if "dash_cytoscape" not in sys.modules:
+        dash_cytoscape_stub = types.ModuleType("dash_cytoscape")
+        dash_cytoscape_stub.Cytoscape = dash_stub.html.__getattr__("cytoscape")  # type: ignore[arg-type]
+        dash_cytoscape_stub.load_extra_layouts = lambda: None
+        sys.modules["dash_cytoscape"] = dash_cytoscape_stub
+
+    if "flask" not in sys.modules:
+        flask_stub = types.ModuleType("flask")
+
+        class Response:
+            def __init__(self, data=None, mimetype=None):
+                self.data = data or ""
+                self.mimetype = mimetype
+                self.headers = {}
+
+            def get_json(self):
+                try:
+                    return json.loads(self.data)
+                except Exception:
+                    return None
+
+        flask_stub.Response = Response
+        sys.modules["flask"] = flask_stub
+
+    return sys.modules["dash"].no_update  # type: ignore[attr-defined]
+
+
+def _assert_root_connections(result, root_id):
+    nodes = {
+        element["data"]["id"]
+        for element in result
+        if "source" not in element.get("data", {})
+    }
+    edges = [element for element in result if "source" in element.get("data", {})]
+
+    assert root_id in nodes
+
+    root_edges = [
+        edge for edge in edges if edge["data"].get("source") == root_id or edge["data"].get("target") == root_id
+    ]
+    assert root_edges
+
+    for edge in root_edges:
+        assert edge["data"]["source"] in nodes
+        assert edge["data"]["target"] in nodes
+
+
+@pytest.mark.parametrize("elements", [None, []])
+@pytest.mark.parametrize("page_range_override", [None, "fixture"])
+def test_expand_on_click_handles_missing_elements_and_page_ranges(elements, page_range_override):
+    document_node, store_graph, node_index, page_range = build_graph_state(FIXTURE)
+
+    no_update = _install_dash_stubs()
+    sys.modules.pop("apps.docling_graph.main", None)
+    main = importlib.import_module("apps.docling_graph.main")
+
+    selected_page_range = page_range if page_range_override == "fixture" else None
+
+    result = main.expand_on_click(
+        document_node["data"],
+        elements,
+        store_graph,
+        node_index,
+        mode="children",
+        page_range=selected_page_range,
+    )
+
+    assert result is not no_update
+
+    _assert_root_connections(result, document_node["data"]["id"])
+
+
+def test_expand_on_click_handles_empty_graph_state():
+    document_node, store_graph, node_index, _page_range = build_graph_state(FIXTURE)
+
+    no_update = _install_dash_stubs()
+    sys.modules.pop("apps.docling_graph.main", None)
+    main = importlib.import_module("apps.docling_graph.main")
+
+    result = main.expand_on_click(
+        document_node["data"],
+        elements=None,
+        store_graph={},
+        node_index=None,
+        mode="children",
+        page_range=None,
+    )
+
+    assert result is no_update
+
+
+def test_expand_on_click_returns_related_edges_for_non_document_nodes():
+    document_node, store_graph, node_index, _page_range = build_graph_state(FIXTURE)
+
+    no_update = _install_dash_stubs()
+    sys.modules.pop("apps.docling_graph.main", None)
+    main = importlib.import_module("apps.docling_graph.main")
+
+    target_edge = next(
+        ed
+        for ed in store_graph["edges"]
+        if ed["data"].get("rel") in {"parent", "children", "captions"}
+    )
+    node_id = target_edge["data"]["source"]
+
+    result = main.expand_on_click(
+        node_index[node_id]["data"],
+        elements=[],
+        store_graph=store_graph,
+        node_index=node_index,
+        mode="children",
+        page_range=None,
+    )
+
+    assert result is not no_update
+
+    nodes = {
+        element["data"]["id"]
+        for element in result
+        if "source" not in element.get("data", {})
+    }
+    edge_ids = {
+        element["data"]["id"]
+        for element in result
+        if "source" in element.get("data", {})
+    }
+
+    assert target_edge["data"]["id"] in edge_ids
+    assert target_edge["data"]["source"] in nodes
+    assert target_edge["data"]["target"] in nodes


### PR DESCRIPTION
## Summary
- scan Docling documents from a configurable root without recursion and expose the list via a no-store API
- refresh the DOCUMENT dropdown from the latest filesystem state and display scan root, counts, and timestamps in the UI
- update tests to cover the new scan behavior, cache headers, and Dash/Flask stubs used in callback tests

## Testing
- PYTHONPATH=. pytest

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69445cc28f6c832ea343acaafe6501b7)