### PR TITLE
Add weighting, theme-aware Cytoscape styling, legend, and exports to docling_graph

### DIFF
--- a/apps/docling_graph/assets/view_options.css
+++ b/apps/docling_graph/assets/view_options.css
@@ -200,6 +200,67 @@
   margin-bottom: 10px;
 }
 
+.control-button {
+  background: #111827;
+  color: #e5e7eb;
+  border: 1px solid #1f2937;
+  border-radius: 8px;
+  padding: 6px 10px;
+  cursor: pointer;
+  margin-right: 8px;
+}
+
+.control-button:hover {
+  border-color: #334155;
+}
+
+.legend-summary {
+  cursor: pointer;
+  font-weight: 600;
+  margin-top: 12px;
+}
+
+.legend-body {
+  padding: 8px 0 4px;
+}
+
+.legend-title {
+  font-size: 12px;
+  opacity: 0.85;
+  margin: 6px 0;
+  font-weight: 600;
+}
+
+.legend-list {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  margin-bottom: 8px;
+}
+
+.legend-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.legend-swatch {
+  width: 12px;
+  height: 12px;
+  border-radius: 3px;
+  border: 1px solid rgba(0, 0, 0, 0.2);
+}
+
+.legend-line {
+  width: 18px;
+  height: 0;
+  border-top: 2px solid;
+}
+
+.legend-label {
+  font-size: 12px;
+}
+
 .control-title {
   font-size: 15px;
   font-weight: 700;

--- a/apps/docling_graph/graph_builder.py
+++ b/apps/docling_graph/graph_builder.py
@@ -8,8 +8,10 @@ import unittest
 from collections.abc import Iterable
 from dataclasses import dataclass
 from pathlib import Path
+import math
 from typing import Any, Dict, List, Optional, Tuple
 
+from .theme import get_node_colors
 
 DOCLING_JSON_ROOT = "/home/hp/docling-ws/data/docling"
 
@@ -130,6 +132,7 @@ def build_graph_from_docling_json(path: str) -> GraphPayload:
     edges: List[Dict[str, Any]] = []
 
     doc_id = _nid(path)
+    body_id = _nid(f"{path}::body")
     doc_name = os.path.basename(path)
 
     # DOCUMENT node
@@ -137,12 +140,40 @@ def build_graph_from_docling_json(path: str) -> GraphPayload:
         {
             "data": {
                 "id": doc_id,
-                "type": "document",
+                "type": "Document",
+                "name": doc_name,
                 "label_short": f"DOCUMENT: {doc_name}",
                 "label_full": f"DOCUMENT: {doc_name}",
                 "label": f"DOCUMENT: {doc_name}",
             },
             "classes": "document",
+        }
+    )
+
+    nodes.append(
+        {
+            "data": {
+                "id": body_id,
+                "type": "Body",
+                "name": "Body",
+                "label_short": "BODY",
+                "label_full": "BODY",
+                "label": "BODY",
+            },
+            "classes": "body",
+        }
+    )
+
+    edges.append(
+        {
+            "data": {
+                "id": _nid(f"{doc_id}__{body_id}__HAS_BODY"),
+                "source": doc_id,
+                "target": body_id,
+                "rel": "HAS_BODY",
+                "type": "HAS_BODY",
+            },
+            "classes": "has-body",
         }
     )
 
@@ -156,29 +187,32 @@ def build_graph_from_docling_json(path: str) -> GraphPayload:
             {
                 "data": {
                     "id": page_id,
-                    "type": "chunk",
+                    "type": "Page",
+                    "name": f"Page {page_no}",
                     "page": page_no,
                     "label_short": f"PAGE {page_no}",
                     "label_full": f"PAGE {page_no}",
                     "label": f"PAGE {page_no}",
                 },
-                "classes": "section",
+                "classes": "page",
             }
         )
 
         edges.append(
             {
                 "data": {
-                    "id": _nid(f"{doc_id}__{page_id}"),
+                    "id": _nid(f"{doc_id}__{page_id}__HAS_PAGE"),
                     "source": doc_id,
                     "target": page_id,
-                    "rel": "hier",
+                    "rel": "HAS_PAGE",
+                    "type": "HAS_PAGE",
                 },
-                "classes": "hier",
+                "classes": "has-page",
             }
         )
 
         page_texts = pages[page_no][:MAX_TEXTS_PER_PAGE]
+        previous_text_id: Optional[str] = None
 
         for t in page_texts:
             ref = t.get("self_ref") or t.get("id") or repr(t)
@@ -196,7 +230,8 @@ def build_graph_from_docling_json(path: str) -> GraphPayload:
                 {
                     "data": {
                         "id": text_id,
-                        "type": "text",
+                        "type": dtype,
+                        "name": _short(raw_text, 140),
                         "content_layer": content_layer,
                         "text": raw_text,
                         "page": page_no,
@@ -205,23 +240,135 @@ def build_graph_from_docling_json(path: str) -> GraphPayload:
                         "label_full": label_full,
                         "label": label_full,
                     },
-                    "classes": "item",
+                    "classes": "text",
                 }
             )
 
             edges.append(
                 {
                     "data": {
-                        "id": _nid(f"{page_id}__{text_id}"),
-                        "source": page_id,
+                        "id": _nid(f"{body_id}__{text_id}__CONTAINS"),
+                        "source": body_id,
                         "target": text_id,
-                        "rel": "hier",
+                        "rel": "CONTAINS",
+                        "type": "CONTAINS",
                     },
-                    "classes": "hier",
+                    "classes": "contains",
                 }
             )
 
+            edges.append(
+                {
+                    "data": {
+                        "id": _nid(f"{page_id}__{text_id}__ON_PAGE"),
+                        "source": page_id,
+                        "target": text_id,
+                        "rel": "ON_PAGE",
+                        "type": "ON_PAGE",
+                    },
+                    "classes": "on-page",
+                }
+            )
+
+            if previous_text_id:
+                edges.append(
+                    {
+                        "data": {
+                            "id": _nid(f"{previous_text_id}__{text_id}__NEXT"),
+                            "source": previous_text_id,
+                            "target": text_id,
+                            "rel": "NEXT",
+                            "type": "NEXT",
+                        },
+                        "classes": "next",
+                    }
+                )
+
+            previous_text_id = text_id
+
+    _apply_weights(nodes, edges)
+
     return GraphPayload(nodes=nodes, edges=edges)
+
+
+def _clamp(value: float, minimum: float, maximum: float) -> float:
+    return max(minimum, min(value, maximum))
+
+
+def _edge_weight(rel: str, target_node: Dict[str, Any]) -> float:
+    if rel == "CONTAINS":
+        text = str(target_node.get("data", {}).get("text") or "")
+        if text:
+            return _clamp(math.ceil(len(text) / 200), 1, 10)
+        return 1
+    return 1
+
+
+def _apply_weights(nodes: List[Dict[str, Any]], edges: List[Dict[str, Any]]) -> None:
+    node_index = {n["data"]["id"]: n for n in nodes}
+
+    for edge in edges:
+        data = edge["data"]
+        source = node_index.get(data.get("source"), {}).get("data", {})
+        target = node_index.get(data.get("target"), {}).get("data", {})
+        weight = _edge_weight(data.get("rel"), target or {})
+        data["weight"] = weight
+        data["width"] = _clamp(1 + (weight * 0.5), 1, 8)
+        data["edge_length"] = _clamp(120 - (weight * 8), 30, 200)
+        data["source_name"] = source.get("name")
+        data["source_type"] = source.get("type")
+        data["target_name"] = target.get("name")
+        data["target_type"] = target.get("type")
+
+    child_edges = {"HAS_PAGE", "HAS_BODY", "CONTAINS", "ON_PAGE"}
+    children_count: Dict[str, int] = {}
+    degree: Dict[str, int] = {}
+
+    for edge in edges:
+        src = edge["data"].get("source")
+        tgt = edge["data"].get("target")
+        rel = edge["data"].get("rel")
+        degree[src] = degree.get(src, 0) + 1
+        degree[tgt] = degree.get(tgt, 0) + 1
+        if rel in child_edges:
+            children_count[src] = children_count.get(src, 0) + 1
+
+    for node in nodes:
+        data = node["data"]
+        node_id = data["id"]
+        text = str(data.get("text") or "")
+        text_len = len(text)
+        count_children = children_count.get(node_id, 0)
+        deg = degree.get(node_id, 0)
+        content = min(5, text_len / 500) if text else 0
+        connectivity = min(5, math.log1p(deg))
+        weight = 1 + (count_children * 0.25) + content + connectivity
+        data["text_length"] = text_len
+        data["children_count"] = count_children
+        data["degree"] = deg
+        data["weight"] = weight
+
+    for node in nodes:
+        data = node["data"]
+        if data.get("type") not in {"Document", "Body"}:
+            continue
+        node_id = data["id"]
+        child_weights = [
+            node_index[edge["data"]["target"]]["data"]["weight"]
+            for edge in edges
+            if edge["data"].get("source") == node_id
+        ]
+        if child_weights:
+            top_weights = sorted(child_weights, reverse=True)[:5]
+            data["weight"] = max(top_weights) + 1
+
+    for node in nodes:
+        data = node["data"]
+        weight = float(data.get("weight") or 1)
+        data["size"] = _clamp(20 + (weight * 6), 20, 80)
+        colors = get_node_colors(data.get("type"))
+        data["color_light"] = colors["light"]
+        data["color_dark"] = colors["dark"]
 
 
 # -----------------------------
@@ -270,19 +417,24 @@ class GraphBuilderTests(unittest.TestCase):
         finally:
             Path(tmp_path).unlink(missing_ok=True)
 
-        self.assertEqual(len(payload.nodes), 3)
-        self.assertEqual(len(payload.edges), 2)
+        self.assertEqual(len(payload.nodes), 4)
+        self.assertEqual(len(payload.edges), 4)
 
         node_ids = {n["data"]["id"] for n in payload.nodes}
         edge_pairs = {(e["data"]["source"], e["data"]["target"]) for e in payload.edges}
 
         doc_id = _nid(tmp_path)
+        body_id = _nid(f"{tmp_path}::body")
         page_id = _nid(f"{tmp_path}::page::1")
-        text_id = next(n["data"]["id"] for n in payload.nodes if n["data"]["type"] == "text")
+        text_id = next(n["data"]["id"] for n in payload.nodes if n["data"].get("text"))
 
         self.assertIn(doc_id, node_ids)
+        self.assertIn(body_id, node_ids)
         self.assertIn(page_id, node_ids)
-        self.assertEqual(edge_pairs, {(doc_id, page_id), (page_id, text_id)})
+        self.assertEqual(
+            edge_pairs,
+            {(doc_id, body_id), (doc_id, page_id), (body_id, text_id), (page_id, text_id)},
+        )
 
     def test_list_docling_files_accepts_custom_root(self):
         with tempfile.TemporaryDirectory() as tmpdir:

--- a/apps/docling_graph/main.py
+++ b/apps/docling_graph/main.py
@@ -2,13 +2,22 @@ from __future__ import annotations
 
 import os
 import json
+import csv
+import io
+import zipfile
+from xml.sax.saxutils import escape
 from dash import Dash, html, dcc, Input, Output, State, no_update
 import dash_cytoscape as cyto
 
-from .graph_builder import (
-    build_graph_from_docling_json,
-    list_docling_files,
-    GraphPayload,
+from .graph_builder import build_graph_from_docling_json, list_docling_files, GraphPayload
+from .theme import (
+    get_cytoscape_stylesheet,
+    get_edge_colors,
+    get_edge_style,
+    get_edge_legend_items,
+    get_node_colors,
+    get_node_legend_items,
+    get_theme_tokens,
 )
 
 APP_DIR = os.path.dirname(os.path.abspath(__file__))
@@ -45,6 +54,7 @@ LAYOUTS = [
     ("Breadthfirst", "breadthfirst"),
     ("Force-directed (COSE)", "cose"),
     ("COSE-Bilkent", "cose-bilkent"),
+    ("fCoSE", "fcose"),
     ("Cola (read text)", "cola"),
     ("Euler (quality force)", "euler"),
 ]
@@ -76,12 +86,12 @@ def layout_for(name: str, scaling_ratio: int):
             "padding": 30,
         }
 
-    if name in ("cose", "cose-bilkent", "euler"):
+    if name in ("cose", "cose-bilkent", "euler", "fcose"):
         return {
             "name": name,
             "animate": True,
             "randomize": False,
-            "idealEdgeLength": int(60 + (s * 0.25)),
+            "idealEdgeLength": "data(edge_length)" if name in ("cose-bilkent", "fcose") else int(60 + (s * 0.25)),
             "nodeRepulsion": int(2000 + (s * 12)),
             "gravity": 0.25,
             "numIter": 1000,
@@ -92,43 +102,10 @@ def layout_for(name: str, scaling_ratio: int):
     return {"name": name, "fit": True, "padding": 30}
 
 
-def base_stylesheet(node_size, font_size, text_max_width, show_edge_labels):
-    return [
-        {
-            "selector": "node",
-            "style": {
-                "label": "data(label)",
-                "font-size": f"{font_size}px",
-                "text-wrap": "wrap",
-                "text-max-width": f"{text_max_width}px",
-                "color": "#E5E7EB",
-                "text-outline-width": 1,
-                "text-outline-color": "#0B1220",
-                "width": f"{node_size}px",
-                "height": f"{node_size}px",
-                "z-index": 9999,
-            },
-        },
-        {
-            "selector": "edge",
-            "style": {
-                "curve-style": "bezier",
-                "line-color": "#64748B",
-                "target-arrow-color": "#64748B",
-                "target-arrow-shape": "triangle",
-                "arrow-scale": 0.8,
-                "opacity": 0.55,
-                "label": "data(rel)" if show_edge_labels else "",
-                "font-size": "9px",
-                "color": "#CBD5E1",
-                "z-index": 5000,
-            },
-        },
-        {"selector": ".document", "style": {"background-color": "#1D4ED8"}},
-        {"selector": ".section", "style": {"background-color": "#111827"}},
-        {"selector": ".item", "style": {"background-color": "#334155"}},
-        {"selector": ":selected", "style": {"border-width": 3, "border-color": "#FBBF24"}},
-    ]
+GRAPH_BASE_STYLE = {
+    "width": "100%",
+    "height": "85vh",
+}
 
 
 # -------------------------------------------------
@@ -143,6 +120,11 @@ DEFAULT_VIEW = {
     "font_size": 10,
     "text_max_width": 520,
     "show_edge_labels": False,
+    "theme": "dark",
+    "scale_node_size": True,
+    "scale_edge_width": True,
+    "min_node_weight": 1,
+    "min_edge_weight": 1,
 }
 
 app = Dash(
@@ -160,6 +142,8 @@ app.layout = html.Div(
     children=[
         dcc.Store(id="store_graph"),
         dcc.Store(id="store_node_index"),
+        dcc.Download(id="download_csv"),
+        dcc.Download(id="download_xlsx"),
 
         html.Div(
             className="row",
@@ -171,9 +155,8 @@ app.layout = html.Div(
                         cyto.Cytoscape(
                             id="graph",
                             style={
-                                "width": "100%",
-                                "height": "85vh",
-                                "backgroundColor": "#0B0F17",
+                                **GRAPH_BASE_STYLE,
+                                "backgroundColor": get_theme_tokens(DEFAULT_VIEW["theme"])["background"],
                             },
                             wheelSensitivity=0.01,
                             minZoom=0.25,
@@ -182,11 +165,14 @@ app.layout = html.Div(
                                 DEFAULT_VIEW["layout"],
                                 DEFAULT_VIEW["scaling_ratio"],
                             ),
-                            stylesheet=base_stylesheet(
-                                DEFAULT_VIEW["node_size"],
-                                DEFAULT_VIEW["font_size"],
-                                DEFAULT_VIEW["text_max_width"],
-                                DEFAULT_VIEW["show_edge_labels"],
+                            stylesheet=get_cytoscape_stylesheet(
+                                DEFAULT_VIEW["theme"],
+                                node_size=DEFAULT_VIEW["node_size"],
+                                font_size=DEFAULT_VIEW["font_size"],
+                                text_max_width=DEFAULT_VIEW["text_max_width"],
+                                show_edge_labels=DEFAULT_VIEW["show_edge_labels"],
+                                scale_node_size=DEFAULT_VIEW["scale_node_size"],
+                                scale_edge_width=DEFAULT_VIEW["scale_edge_width"],
                             ),
                             elements=[],
                         )
@@ -266,6 +252,22 @@ app.layout = html.Div(
                                                 html.Div(
                                                     className="control-section",
                                                     children=[
+                                                        html.Div("Theme", className="control-label"),
+                                                        dcc.RadioItems(
+                                                            id="theme",
+                                                            options=[
+                                                                {"label": "Light", "value": "light"},
+                                                                {"label": "Dark", "value": "dark"},
+                                                            ],
+                                                            value=DEFAULT_VIEW["theme"],
+                                                            inputClassName="control-radio",
+                                                            labelClassName="control-radio__label",
+                                                        ),
+                                                    ],
+                                                ),
+                                                html.Div(
+                                                    className="control-section",
+                                                    children=[
                                                         html.Div("Scaling ratio", className="control-label"),
                                                         dcc.Slider(
                                                             id="scaling_ratio",
@@ -304,6 +306,70 @@ app.layout = html.Div(
                                                             labelClassName="control-checkbox__label",
                                                         ),
                                                     ],
+                                                ),
+                                                html.Div(
+                                                    className="control-section",
+                                                    children=[
+                                                        html.Div("Weights", className="control-label"),
+                                                        dcc.Checklist(
+                                                            id="weight_toggles",
+                                                            options=[
+                                                                {"label": " Scale node size by weight", "value": "node"},
+                                                                {"label": " Scale edge width by weight", "value": "edge"},
+                                                                {"label": " Keep context when filtering", "value": "context"},
+                                                            ],
+                                                            value=["node", "edge"],
+                                                            inputClassName="control-checkbox",
+                                                            labelClassName="control-checkbox__label",
+                                                        ),
+                                                    ],
+                                                ),
+                                                html.Div(
+                                                    className="control-section",
+                                                    children=[
+                                                        html.Div("Min node weight", className="control-label"),
+                                                        dcc.Slider(
+                                                            id="min_node_weight",
+                                                            min=1,
+                                                            max=15,
+                                                            step=0.5,
+                                                            value=DEFAULT_VIEW["min_node_weight"],
+                                                        ),
+                                                    ],
+                                                ),
+                                                html.Div(
+                                                    className="control-section",
+                                                    children=[
+                                                        html.Div("Min edge weight", className="control-label"),
+                                                        dcc.Slider(
+                                                            id="min_edge_weight",
+                                                            min=1,
+                                                            max=10,
+                                                            step=1,
+                                                            value=DEFAULT_VIEW["min_edge_weight"],
+                                                        ),
+                                                    ],
+                                                ),
+                                                html.Div(
+                                                    className="control-section",
+                                                    children=[
+                                                        html.Div("Exports", className="control-label"),
+                                                        html.Button("Download CSV", id="export_csv", className="control-button"),
+                                                        html.Button("Download XLSX", id="export_xlsx", className="control-button"),
+                                                    ],
+                                                ),
+                                                html.Div(
+                                                    className="control-section",
+                                                    children=[
+                                                        html.Div("Hover details", className="control-label"),
+                                                        html.Pre(id="hover-node-output", style={"whiteSpace": "pre-wrap"}),
+                                                        html.Pre(id="hover-edge-output", style={"whiteSpace": "pre-wrap"}),
+                                                    ],
+                                                ),
+                                                html.Details(
+                                                    id="legend_container",
+                                                    open=True,
+                                                    children=[],
                                                 ),
                                             ],
                                         )
@@ -358,7 +424,7 @@ def load_graph(path):
     node_index = {n["data"]["id"]: n for n in g.nodes if n.get("data", {}).get("id")}
 
     # Genesis node: document
-    doc_node = next((n for n in g.nodes if n["data"].get("type") == "document"), None)
+    doc_node = next((n for n in g.nodes if n["data"].get("type") == "Document"), None)
     elements = [doc_node] if doc_node else []
 
     store_graph = {"nodes": g.nodes, "edges": g.edges}
@@ -431,11 +497,12 @@ def expand_on_click(node_data, elements, store_graph, node_index, mode, page_ran
     new_nodes = []
     new_edges = []
 
+    child_edges = {"HAS_PAGE", "HAS_BODY", "CONTAINS", "ON_PAGE"}
     for ed in store_graph["edges"]:
         d = ed["data"]
         src, tgt, rel = d.get("source"), d.get("target"), d.get("rel")
 
-        if mode == "children" and not (rel == "hier" and src == node_id):
+        if mode == "children" and not (rel in child_edges and src == node_id):
             continue
         if mode == "out" and src != node_id:
             continue
@@ -476,12 +543,19 @@ def update_layout(name, scaling):
 @app.callback(
     Output("graph", "elements", allow_duplicate=True),
     Input("page_range", "value"),
+    Input("min_node_weight", "value"),
+    Input("min_edge_weight", "value"),
+    Input("weight_toggles", "value"),
     State("graph", "elements"),
     prevent_initial_call=True,
 )
-def filter_elements_by_page(page_range, elements):
+def filter_elements_by_page(page_range, min_node_weight, min_edge_weight, weight_toggles, elements):
     if not page_range or not elements:
         return no_update
+
+    keep_context = "context" in (weight_toggles or [])
+    node_threshold = float(min_node_weight or 1)
+    edge_threshold = float(min_edge_weight or 1)
 
     start_page, end_page = page_range
     allowed_nodes = set()
@@ -493,17 +567,40 @@ def filter_elements_by_page(page_range, elements):
             continue
 
         page = data.get("page")
+        weight = float(data.get("weight") or 0)
         if page is None or (start_page <= page <= end_page):
-            allowed_nodes.add(data.get("id"))
-            filtered_nodes.append(el)
+            if weight >= node_threshold:
+                allowed_nodes.add(data.get("id"))
+                filtered_nodes.append(el)
 
-    filtered_edges = [
-        el
-        for el in elements
-        if "source" in el.get("data", {})
-        and el["data"].get("source") in allowed_nodes
-        and el["data"].get("target") in allowed_nodes
-    ]
+    filtered_edges = []
+    context_nodes = set()
+    for el in elements:
+        data = el.get("data", {})
+        if "source" not in data:
+            continue
+        weight = float(data.get("weight") or 0)
+        if weight < edge_threshold:
+            continue
+        src = data.get("source")
+        tgt = data.get("target")
+        if src in allowed_nodes and tgt in allowed_nodes:
+            filtered_edges.append(el)
+        elif keep_context and (src in allowed_nodes or tgt in allowed_nodes):
+            context_nodes.update([src, tgt])
+            filtered_edges.append(el)
+
+    if keep_context and context_nodes:
+        for el in elements:
+            data = el.get("data", {})
+            if "source" in data:
+                continue
+            node_id = data.get("id")
+            page = data.get("page")
+            if node_id in context_nodes and (page is None or (start_page <= page <= end_page)):
+                if node_id not in allowed_nodes:
+                    allowed_nodes.add(node_id)
+                    filtered_nodes.append(el)
 
     return filtered_nodes + filtered_edges
 
@@ -511,14 +608,97 @@ def filter_elements_by_page(page_range, elements):
 @app.callback(
     Output("graph", "stylesheet"),
     Input("edge_labels", "value"),
+    Input("weight_toggles", "value"),
+    Input("theme", "value"),
 )
-def update_styles(edge_labels):
-    return base_stylesheet(
-        DEFAULT_VIEW["node_size"],
-        DEFAULT_VIEW["font_size"],
-        DEFAULT_VIEW["text_max_width"],
-        "on" in (edge_labels or []),
+def update_styles(edge_labels, weight_toggles, theme):
+    weight_toggles = weight_toggles or []
+    return get_cytoscape_stylesheet(
+        theme or DEFAULT_VIEW["theme"],
+        node_size=DEFAULT_VIEW["node_size"],
+        font_size=DEFAULT_VIEW["font_size"],
+        text_max_width=DEFAULT_VIEW["text_max_width"],
+        show_edge_labels="on" in (edge_labels or []),
+        scale_node_size="node" in weight_toggles,
+        scale_edge_width="edge" in weight_toggles,
     )
+
+
+@app.callback(
+    Output("graph", "style"),
+    Input("theme", "value"),
+)
+def update_graph_style(theme):
+    tokens = get_theme_tokens(theme or DEFAULT_VIEW["theme"])
+    return {
+        **GRAPH_BASE_STYLE,
+        "backgroundColor": tokens["background"],
+    }
+
+
+def build_legend(theme: str):
+    tokens = get_theme_tokens(theme)
+    node_items = []
+    for item in get_node_legend_items():
+        colors = get_node_colors(item["type"])
+        node_items.append(
+            html.Div(
+                className="legend-row",
+                children=[
+                    html.Span(className="legend-swatch", style={"backgroundColor": colors[theme]}),
+                    html.Span(item["label"], className="legend-label"),
+                ],
+            )
+        )
+
+    edge_items = []
+    for item in get_edge_legend_items():
+        colors = get_edge_colors(item["type"])
+        edge_style = get_edge_style(item["type"])
+        edge_items.append(
+            html.Div(
+                className="legend-row",
+                children=[
+                    html.Span(
+                        className="legend-line",
+                        style={
+                            "borderColor": colors[theme],
+                            "borderStyle": edge_style.get("line-style", "solid"),
+                            "borderWidth": "3px" if edge_style.get("thick") else "2px",
+                        },
+                    ),
+                    html.Span(item["label"], className="legend-label"),
+                ],
+            )
+        )
+
+    return [
+        html.Summary("Legend", className="legend-summary"),
+        html.Div(
+            className="legend-body",
+            children=[
+                html.Div("Node Types", className="legend-title"),
+                html.Div(node_items, className="legend-list"),
+                html.Div("Edge Types", className="legend-title"),
+                html.Div(edge_items, className="legend-list"),
+            ],
+        ),
+    ]
+
+
+@app.callback(
+    Output("legend_container", "children"),
+    Output("legend_container", "style"),
+    Input("theme", "value"),
+)
+def update_legend(theme):
+    tokens = get_theme_tokens(theme or DEFAULT_VIEW["theme"])
+    style = {
+        "backgroundColor": tokens["panel"],
+        "color": tokens["text"],
+        "border": f"1px solid {tokens['panel_border']}",
+    }
+    return build_legend(theme or DEFAULT_VIEW["theme"]), style
 
 
 @app.callback(
@@ -535,6 +715,179 @@ def show_node(data):
 )
 def show_edge(data):
     return json.dumps(data, indent=2)
+
+
+def _column_letter(index: int) -> str:
+    letter = ""
+    while index:
+        index, remainder = divmod(index - 1, 26)
+        letter = chr(65 + remainder) + letter
+    return letter
+
+
+def _sheet_xml(rows):
+    lines = ['<?xml version="1.0" encoding="UTF-8"?>']
+    lines.append('<worksheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main">')
+    lines.append("<sheetData>")
+    for r_index, row in enumerate(rows, start=1):
+        lines.append(f'<row r="{r_index}">')
+        for c_index, value in enumerate(row, start=1):
+            cell_ref = f"{_column_letter(c_index)}{r_index}"
+            if isinstance(value, (int, float)) and not isinstance(value, bool):
+                lines.append(f'<c r="{cell_ref}"><v>{value}</v></c>')
+            else:
+                safe = escape(str(value))
+                lines.append(f'<c r="{cell_ref}" t="inlineStr"><is><t>{safe}</t></is></c>')
+        lines.append("</row>")
+    lines.append("</sheetData>")
+    lines.append("</worksheet>")
+    return "\n".join(lines)
+
+
+def _build_xlsx(nodes_rows, edges_rows):
+    workbook = """<?xml version="1.0" encoding="UTF-8"?>
+<workbook xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main"
+xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
+  <sheets>
+    <sheet name="Nodes" sheetId="1" r:id="rId1"/>
+    <sheet name="Edges" sheetId="2" r:id="rId2"/>
+  </sheets>
+</workbook>
+"""
+    rels = """<?xml version="1.0" encoding="UTF-8"?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  <Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet" Target="worksheets/sheet1.xml"/>
+  <Relationship Id="rId2" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet" Target="worksheets/sheet2.xml"/>
+</Relationships>
+"""
+    root_rels = """<?xml version="1.0" encoding="UTF-8"?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  <Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="xl/workbook.xml"/>
+</Relationships>
+"""
+    content_types = """<?xml version="1.0" encoding="UTF-8"?>
+<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">
+  <Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>
+  <Default Extension="xml" ContentType="application/xml"/>
+  <Override PartName="/xl/workbook.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet.main+xml"/>
+  <Override PartName="/xl/worksheets/sheet1.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml"/>
+  <Override PartName="/xl/worksheets/sheet2.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml"/>
+</Types>
+"""
+    output = io.BytesIO()
+    with zipfile.ZipFile(output, "w", compression=zipfile.ZIP_DEFLATED) as zf:
+        zf.writestr("[Content_Types].xml", content_types)
+        zf.writestr("_rels/.rels", root_rels)
+        zf.writestr("xl/workbook.xml", workbook)
+        zf.writestr("xl/_rels/workbook.xml.rels", rels)
+        zf.writestr("xl/worksheets/sheet1.xml", _sheet_xml(nodes_rows))
+        zf.writestr("xl/worksheets/sheet2.xml", _sheet_xml(edges_rows))
+    return output.getvalue()
+
+
+def _build_export_rows(store_graph):
+    node_index = {n["data"]["id"]: n for n in store_graph.get("nodes", [])}
+    nodes_rows = [["Type", "Name", "Image", "Weight"]]
+    for node in store_graph.get("nodes", []):
+        data = node["data"]
+        nodes_rows.append(
+            [
+                data.get("type", ""),
+                data.get("name", ""),
+                data.get("image", ""),
+                round(float(data.get("weight") or 1), 3),
+            ]
+        )
+
+    edges_rows = [["From Type", "From Name", "To Type", "To Name", "Weight"]]
+    for edge in store_graph.get("edges", []):
+        data = edge["data"]
+        source = node_index.get(data.get("source"), {}).get("data", {})
+        target = node_index.get(data.get("target"), {}).get("data", {})
+        edges_rows.append(
+            [
+                source.get("type", ""),
+                source.get("name", ""),
+                target.get("type", ""),
+                target.get("name", ""),
+                round(float(data.get("weight") or 1), 3),
+            ]
+        )
+    return nodes_rows, edges_rows
+
+
+@app.callback(
+    Output("download_csv", "data"),
+    Input("export_csv", "n_clicks"),
+    State("store_graph", "data"),
+    prevent_initial_call=True,
+)
+def export_csv(n_clicks, store_graph):
+    if not n_clicks or not store_graph:
+        return no_update
+
+    nodes_rows, edges_rows = _build_export_rows(store_graph)
+    output = io.BytesIO()
+    with zipfile.ZipFile(output, "w", compression=zipfile.ZIP_DEFLATED) as zf:
+        nodes_buffer = io.StringIO()
+        edges_buffer = io.StringIO()
+        csv.writer(nodes_buffer).writerows(nodes_rows)
+        csv.writer(edges_buffer).writerows(edges_rows)
+        zf.writestr("nodes.csv", nodes_buffer.getvalue())
+        zf.writestr("edges.csv", edges_buffer.getvalue())
+    return dcc.send_bytes(output.getvalue(), "graph_commons_csv.zip")
+
+
+@app.callback(
+    Output("download_xlsx", "data"),
+    Input("export_xlsx", "n_clicks"),
+    State("store_graph", "data"),
+    prevent_initial_call=True,
+)
+def export_xlsx(n_clicks, store_graph):
+    if not n_clicks or not store_graph:
+        return no_update
+
+    nodes_rows, edges_rows = _build_export_rows(store_graph)
+    return dcc.send_bytes(_build_xlsx(nodes_rows, edges_rows), "graph_commons.xlsx")
+
+
+@app.callback(
+    Output("hover-node-output", "children"),
+    Input("graph", "mouseoverNodeData"),
+)
+def show_hover_node(data):
+    if not data:
+        return "Hover a node to see details."
+
+    return "\n".join(
+        [
+            f"Type: {data.get('type')}",
+            f"Name: {data.get('name')}",
+            f"Weight: {round(float(data.get('weight') or 0), 3)}",
+            f"Degree: {data.get('degree')}",
+            f"Text length: {data.get('text_length')}",
+            f"Children count: {data.get('children_count')}",
+        ]
+    )
+
+
+@app.callback(
+    Output("hover-edge-output", "children"),
+    Input("graph", "mouseoverEdgeData"),
+)
+def show_hover_edge(data):
+    if not data:
+        return "Hover an edge to see details."
+
+    return "\n".join(
+        [
+            f"Edge Type: {data.get('rel')}",
+            f"Weight: {round(float(data.get('weight') or 0), 3)}",
+            f"Source: {data.get('source_type')} · {data.get('source_name')}",
+            f"Target: {data.get('target_type')} · {data.get('target_name')}",
+        ]
+    )
 
 
 # -------------------------------------------------

--- a/apps/docling_graph/theme.py
+++ b/apps/docling_graph/theme.py
@@ -1,0 +1,216 @@
+from __future__ import annotations
+
+import hashlib
+from typing import Dict, List
+
+
+THEME_TOKENS = {
+    "light": {
+        "background": "#F8FAFC",
+        "panel": "#FFFFFF",
+        "panel_border": "#E2E8F0",
+        "text": "#0F172A",
+        "label": "#0B1220",
+        "edge_label": "#334155",
+        "selected": "#2563EB",
+        "hover": "#60A5FA",
+    },
+    "dark": {
+        "background": "#0B0F17",
+        "panel": "#0F172A",
+        "panel_border": "#1F2937",
+        "text": "#E5E7EB",
+        "label": "#F8FAFC",
+        "edge_label": "#CBD5E1",
+        "selected": "#FBBF24",
+        "hover": "#94A3B8",
+    },
+}
+
+NODE_COLOR_MAP = {
+    "document": {"light": "#2563EB", "dark": "#60A5FA"},
+    "body": {"light": "#0EA5E9", "dark": "#38BDF8"},
+    "page": {"light": "#475569", "dark": "#94A3B8"},
+    "section_header": {"light": "#7C3AED", "dark": "#C4B5FD"},
+    "heading": {"light": "#7C3AED", "dark": "#C4B5FD"},
+    "title": {"light": "#7C3AED", "dark": "#C4B5FD"},
+    "paragraph": {"light": "#16A34A", "dark": "#4ADE80"},
+    "table": {"light": "#F59E0B", "dark": "#FBBF24"},
+    "picture": {"light": "#EC4899", "dark": "#F472B6"},
+    "footer": {"light": "#6B7280", "dark": "#9CA3AF"},
+    "page_header": {"light": "#0F766E", "dark": "#5EEAD4"},
+    "unknown": {"light": "#64748B", "dark": "#94A3B8"},
+}
+
+FALLBACK_NODE_COLORS = [
+    {"light": "#0EA5E9", "dark": "#7DD3FC"},
+    {"light": "#8B5CF6", "dark": "#C4B5FD"},
+    {"light": "#10B981", "dark": "#6EE7B7"},
+    {"light": "#F97316", "dark": "#FDBA74"},
+    {"light": "#E11D48", "dark": "#FDA4AF"},
+]
+
+EDGE_COLOR_MAP = {
+    "HAS_BODY": {"light": "#1D4ED8", "dark": "#60A5FA"},
+    "HAS_PAGE": {"light": "#1E40AF", "dark": "#93C5FD"},
+    "CONTAINS": {"light": "#0F172A", "dark": "#E2E8F0"},
+    "NEXT": {"light": "#334155", "dark": "#CBD5E1"},
+    "ON_PAGE": {"light": "#475569", "dark": "#94A3B8"},
+}
+
+EDGE_STYLE_MAP = {
+    "HAS_BODY": {"line-style": "solid", "thick": True},
+    "HAS_PAGE": {"line-style": "solid", "thick": True},
+    "CONTAINS": {"line-style": "solid", "thick": False},
+    "NEXT": {"line-style": "dashed", "thick": False},
+    "ON_PAGE": {"line-style": "dotted", "thick": False},
+}
+
+
+def normalize_node_type(node_type: str | None) -> str:
+    if not node_type:
+        return "unknown"
+    return str(node_type).strip().lower().replace(" ", "_")
+
+
+def get_node_colors(node_type: str | None) -> Dict[str, str]:
+    normalized = normalize_node_type(node_type)
+    if normalized in NODE_COLOR_MAP:
+        return NODE_COLOR_MAP[normalized]
+    digest = hashlib.md5(normalized.encode("utf-8")).hexdigest()
+    index = int(digest[:2], 16) % len(FALLBACK_NODE_COLORS)
+    return FALLBACK_NODE_COLORS[index]
+
+
+def get_edge_colors(edge_type: str | None) -> Dict[str, str]:
+    return EDGE_COLOR_MAP.get(edge_type or "", EDGE_COLOR_MAP["CONTAINS"])
+
+
+def get_edge_style(edge_type: str | None) -> Dict[str, str | bool]:
+    return EDGE_STYLE_MAP.get(edge_type or "", EDGE_STYLE_MAP["CONTAINS"])
+
+
+def get_cytoscape_stylesheet(
+    theme: str,
+    *,
+    node_size: int,
+    font_size: int,
+    text_max_width: int,
+    show_edge_labels: bool,
+    scale_node_size: bool,
+    scale_edge_width: bool,
+) -> List[Dict[str, Dict[str, str]]]:
+    tokens = THEME_TOKENS[theme]
+    node_width = "data(size)" if scale_node_size else f"{node_size}px"
+    node_height = "data(size)" if scale_node_size else f"{node_size}px"
+    edge_width = "data(width)" if scale_edge_width else 1.5
+
+    stylesheet = [
+        {
+            "selector": "node",
+            "style": {
+                "label": "data(label)",
+                "font-size": f"{font_size}px",
+                "text-wrap": "wrap",
+                "text-max-width": f"{text_max_width}px",
+                "color": tokens["label"],
+                "text-outline-width": 1,
+                "text-outline-color": tokens["background"],
+                "width": node_width,
+                "height": node_height,
+                "border-width": 1,
+                "border-color": tokens["panel_border"],
+                "background-color": f"data(color_{theme})",
+                "z-index": 9999,
+            },
+        },
+        {
+            "selector": "edge",
+            "style": {
+                "curve-style": "bezier",
+                "line-color": tokens["edge_label"],
+                "target-arrow-color": tokens["edge_label"],
+                "target-arrow-shape": "triangle",
+                "arrow-scale": 0.8,
+                "opacity": 0.65,
+                "label": "data(rel)" if show_edge_labels else "",
+                "font-size": "9px",
+                "color": tokens["edge_label"],
+                "width": edge_width,
+                "z-index": 5000,
+            },
+        },
+        {
+            "selector": ":selected",
+            "style": {
+                "border-width": 3,
+                "border-color": tokens["selected"],
+            },
+        },
+        {
+            "selector": "node:hover",
+            "style": {
+                "border-width": 2,
+                "border-color": tokens["hover"],
+                "shadow-blur": 8,
+                "shadow-color": tokens["hover"],
+                "shadow-opacity": 0.35,
+            },
+        },
+        {
+            "selector": "edge:hover",
+            "style": {
+                "line-color": tokens["hover"],
+                "target-arrow-color": tokens["hover"],
+            },
+        },
+    ]
+
+    for edge_type, colors in EDGE_COLOR_MAP.items():
+        edge_style = EDGE_STYLE_MAP.get(edge_type, {})
+        style = {
+            "line-color": colors[theme],
+            "target-arrow-color": colors[theme],
+        }
+        if edge_style.get("line-style"):
+            style["line-style"] = edge_style["line-style"]
+        if edge_style.get("thick"):
+            style["width"] = "data(width)" if scale_edge_width else 2.5
+        stylesheet.append(
+            {
+                "selector": f'edge[rel = "{edge_type}"]',
+                "style": style,
+            }
+        )
+
+    return stylesheet
+
+
+def get_theme_tokens(theme: str) -> Dict[str, str]:
+    return THEME_TOKENS[theme]
+
+
+def get_node_legend_items() -> List[Dict[str, str]]:
+    return [
+        {"label": "Document", "type": "Document"},
+        {"label": "Body", "type": "Body"},
+        {"label": "Page", "type": "Page"},
+        {"label": "Section header", "type": "SECTION_HEADER"},
+        {"label": "Heading / Title", "type": "HEADING"},
+        {"label": "Paragraph", "type": "PARAGRAPH"},
+        {"label": "Table", "type": "TABLE"},
+        {"label": "Picture", "type": "PICTURE"},
+        {"label": "Footer", "type": "FOOTER"},
+        {"label": "Page header", "type": "PAGE_HEADER"},
+        {"label": "Unknown", "type": "unknown"},
+    ]
+
+
+def get_edge_legend_items() -> List[Dict[str, str]]:
+    return [
+        {"label": "HAS_BODY", "type": "HAS_BODY"},
+        {"label": "HAS_PAGE", "type": "HAS_PAGE"},
+        {"label": "CONTAINS", "type": "CONTAINS"},
+        {"label": "NEXT", "type": "NEXT"},
+        {"label": "ON_PAGE", "type": "ON_PAGE"},
+    ]


### PR DESCRIPTION
### Motivation
- Make node/edge weights first-class so content/structure importance is visible and filterable (Graph‑Commons style). 
- Surface weight metadata in tooltips and allow size/width scaling + min-weight filters to reduce clutter.
- Provide a deterministic light/dark color scheme and a legend so node/edge types remain distinguishable and accessible.
- Add export parity (CSV/XLSX) including computed `Weight` columns for nodes/edges.

### Description
- Graph model & weights (`apps/docling_graph/graph_builder.py`)
  - Added `Body` node and new edge types: `HAS_BODY`, `HAS_PAGE`, `CONTAINS`, `ON_PAGE`, `NEXT` and normalized `type`/`name` fields.
  - Implemented deterministic edge weights (CONTAINS = ceil(len(text)/200) clamped 1..10; others default to 1) and derived edge props (`width`, `edge_length`).
  - Implemented node weight rules (base + structural + content + connectivity, with Document/Body using max(top-k children)+1) and derived `size`, `text_length`, `children_count`, `degree`.
  - Emit per-node color hints (`color_light` / `color_dark`) for use by the stylesheet.
- UI, styling & exports (`apps/docling_graph/main.py`, `apps/docling_graph/assets/view_options.css`)
  - Added UI controls: theme toggle (Light/Dark), `weight_toggles` (scale node/edge), `min_node_weight` / `min_edge_weight` sliders, export buttons, hover detail readouts and a collapsible legend panel.
  - Wired layout to prefer weighted layouts (`cose-bilkent` / `fcose`) by mapping `edge_length` to layout where available.
  - Implemented CSV export (zipped nodes.csv / edges.csv) and a minimal XLSX builder that includes Type/Name and Weight columns.
  - Minor CSS: `.control-button` and legend styles added.
- Centralized theme & Cytoscape stylesheet (`apps/docling_graph/theme.py`)
  - New `theme.py` holds `THEME_TOKENS`, deterministic `NODE_COLOR_MAP` / `EDGE_COLOR_MAP`, and `get_cytoscape_stylesheet(theme, ...)` which returns a Cytoscape stylesheet suitable for light/dark themes and for enabling `data(size)` / `data(width)` usage.

### Testing
- Unit tests: ran `python -m unittest apps.docling_graph.graph_builder` — all tests passed (4 tests, OK).
- UI start attempt: `python apps/docling_graph/main.py` could not be executed in the sandbox due to a missing runtime dependency (`ModuleNotFoundError: No module named 'dash'`) — this is environment-related, not a code failure.
- Files touched: `apps/docling_graph/graph_builder.py`, `apps/docling_graph/main.py`, `apps/docling_graph/theme.py`, `apps/docling_graph/assets/view_options.css`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69457bc26248832eb0a80d0e47ce4dc7)